### PR TITLE
feat(tcp-api): start working on protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "critical-section"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +224,7 @@ name = "dechib_api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "crc",
  "dechib_auth",
  "dechib_core",
  "tokio",

--- a/dechib/examples/api_example.rs
+++ b/dechib/examples/api_example.rs
@@ -1,0 +1,9 @@
+use dechib_api::api::launch_server;
+use dechib_core::{setup_logging, Instance};
+
+fn main() {
+    setup_logging();
+
+    let instance = Instance::new();
+    launch_server(instance).expect("error while starting api server");
+}

--- a/dechib_api/Cargo.toml
+++ b/dechib_api/Cargo.toml
@@ -14,5 +14,6 @@ crate-type = ["lib"]
 [dependencies]
 tokio = {  version = "1.39.3", features = ["full"] }
 anyhow = "1.0.86"
+crc = "3.2.1"
 dechib_core = {path = "../dechib_core"}
 dechib_auth = {path = "../dechib_auth"}

--- a/dechib_api/src/api.rs
+++ b/dechib_api/src/api.rs
@@ -1,9 +1,12 @@
+use crate::types::DechibMessage;
 use dechib_core::Instance;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::runtime::Runtime;
 
-pub fn launch_server(instance: Instance) -> anyhow::Result<()> {
+const MAX_BUFFER: usize = u16::MAX as usize;
+
+pub fn launch_server(_instance: Instance) -> anyhow::Result<()> {
     let rt = Runtime::new()?;
 
     rt.block_on(async {
@@ -11,22 +14,23 @@ pub fn launch_server(instance: Instance) -> anyhow::Result<()> {
         loop {
             let (mut socket, _) = listener.accept().await?;
             tokio::spawn(async move {
-                let mut queue = String::new();
+                let mut buf = [0u8; MAX_BUFFER];
                 loop {
-                    let mut temp = String::new();
-                    socket.read_to_string(&mut temp);
-                    queue.extend(vec![temp]);
-                    let commands = queue.split("\n").collect::<Vec<&str>>();
-                    if !commands.is_empty() {
-                        let len = if queue.ends_with("\n") {
-                            commands.len()
-                        } else {
-                            commands.len() - 1
-                        };
-                        for command in commands.iter().take(len) {
-                            //instance.execute(command);
+                    let n = match socket.read(&mut buf).await {
+                        Ok(n) if n == 0 => break,
+                        Ok(n) => n,
+                        Err(e) => {
+                            eprintln!("Failed to read from socket; err = {:?}", e);
+                            break;
                         }
-                        // instance.execute(
+                    };
+
+                    let message =
+                        DechibMessage::try_from(&buf[..n]).unwrap_or_else(|err| panic!("{}", err));
+
+                    if let Err(error) = socket.write_all(&message.message_content[..]).await {
+                        eprintln!("failed to write to socket: {:?}", error);
+                        break;
                     }
                 }
             });

--- a/dechib_api/src/lib.rs
+++ b/dechib_api/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod api;
+mod types;

--- a/dechib_api/src/types.rs
+++ b/dechib_api/src/types.rs
@@ -1,0 +1,160 @@
+use anyhow::Error;
+use std::iter::Enumerate;
+use std::slice::Iter;
+
+#[derive(PartialOrd, PartialEq)]
+pub struct DechibMessage {
+    pub(crate) message_type: MessageType,
+    pub(crate) message_size: usize,
+    pub(crate) message_content: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, PartialOrd)]
+pub enum MessageType {
+    Init,
+    Message,
+}
+
+impl DechibMessage {
+    pub fn from_message_type(
+        enumerable_value: &mut Enumerate<Iter<u8>>,
+        message_type: MessageType,
+    ) -> Result<DechibMessage, Error> {
+        if let Some((_, message_size)) = enumerable_value.next() {
+            let message_size = message_size.to_owned() as usize;
+
+            let mut message_content: Vec<u8> = enumerable_value
+                .take(message_size)
+                .map(|(_, val)| *val)
+                .collect();
+
+            if message_content.len() < message_size {
+                message_content.resize(message_size, 0);
+            }
+
+            Ok(DechibMessage {
+                message_type,
+                message_size,
+                message_content,
+            })
+        } else {
+            Err(Error::msg("incoming message does not contain message_size"))
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for DechibMessage {
+    type Error = Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let mut enumerable_value = value.into_iter().enumerate();
+        if let Some((_, val)) = enumerable_value.next() {
+            let val_char = char::try_from(val.to_owned()).unwrap_or_else(|err| panic!("{}", err));
+
+            match val_char {
+                'I' => Self::from_message_type(&mut enumerable_value, MessageType::Init),
+                'M' => Self::from_message_type(&mut enumerable_value, MessageType::Message),
+                _ => Err(Error::msg(
+                    "message_type is not \'I\' (init_mode) or \'M\' (message_mode)",
+                )),
+            }
+        } else {
+            Err(Error::msg(
+                "incoming message does not contain a message_type",
+            ))
+        }
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_try_from() {
+        let input: &[u8] = &[b'M', 5, b'h', b'e', b'l', b'l', b'o'];
+        let result = DechibMessage::try_from(input).unwrap();
+        let expected = DechibMessage {
+            message_type: MessageType::Message,
+            message_size: 5,
+            message_content: vec![104, 101, 108, 108, 111],
+        };
+
+        assert_eq!(result.message_size, expected.message_size);
+        assert_eq!(result.message_content, expected.message_content);
+        assert_eq!(result.message_type, expected.message_type)
+    }
+
+    #[test]
+    fn should_fail_try_from_wrong_msg_type() {
+        let expected_error = "message_type is not \'I\' (init_mode) or \'M\' (message_mode)";
+        let input: &[u8] = &[b'Z', 5, b'h', b'e', b'l', b'l', b'o'];
+        match DechibMessage::try_from(input) {
+            Ok(v) => {
+                panic!("should not have succeeded");
+            }
+            Err(error) => {
+                assert_eq!(error.to_string(), expected_error);
+            }
+        }
+    }
+
+    #[test]
+    fn should_fail_try_from_wrong_size() {
+        let expected_error = "incoming message does not contain message_size";
+        let input: &[u8] = &[b'M'];
+        match DechibMessage::try_from(input) {
+            Ok(v) => {
+                panic!("should not have succeeded");
+            }
+            Err(error) => {
+                assert_eq!(error.to_string(), expected_error);
+            }
+        }
+    }
+
+    #[test]
+    fn should_only_get_message_content_with_size() {
+        let input: &[u8] = &[b'M', 5, b'h', b'e', b'l', b'l', b'o', b'f', b'o', b'o'];
+        let result = DechibMessage::try_from(input).unwrap();
+        let expected = DechibMessage {
+            message_type: MessageType::Message,
+            message_size: 5,
+            // does not contain b"foo"
+            message_content: vec![104, 101, 108, 108, 111],
+        };
+
+        assert_eq!(result.message_size, expected.message_size);
+        assert_eq!(result.message_content, expected.message_content);
+        assert_eq!(result.message_type, expected.message_type)
+    }
+
+    #[test]
+    fn content_less_then_size() {
+        let input: &[u8] = &[b'M', 5, b'h', b'e'];
+        let result = DechibMessage::try_from(input).unwrap();
+        let expected = DechibMessage {
+            message_type: MessageType::Message,
+            message_size: 5,
+            message_content: vec![104, 101, 0, 0, 0],
+        };
+
+        assert_eq!(result.message_size, expected.message_size);
+        assert_eq!(result.message_content, expected.message_content);
+        assert_eq!(result.message_type, expected.message_type)
+    }
+
+    #[test]
+    fn content_is_zero() {
+        let input: &[u8] = &[b'M', 5];
+        let result = DechibMessage::try_from(input).unwrap();
+        let expected = DechibMessage {
+            message_type: MessageType::Message,
+            message_size: 5,
+            message_content: vec![0, 0, 0, 0, 0],
+        };
+
+        assert_eq!(result.message_size, expected.message_size);
+        assert_eq!(result.message_content, expected.message_content);
+        assert_eq!(result.message_type, expected.message_type)
+    }
+}


### PR DESCRIPTION
This is the beginning work for the TCP protocol. The current changes are only for parsing the incoming messages from the client and building a `DechibMessage` for usage within the API server. The current work still needs to be done (maybe in another PR): 
- Implement logic in the API to execute on the `message_content` given a message is of type `M`
- Implement an auth system in `dechib_auth` for usage within the API. I will need to probably write up another RFC more in depth on Authentication and sessions for clients.
- Implement CRC check when parsing message.